### PR TITLE
changed to music album

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,15 +61,15 @@
       <music-topbar></music-topbar>
       <div class="content">
         <music-section
-          title="Featured Tracks"
-          tracks='[
+          title="Featured Albums"
+          albums='[
             {"imageSrc": "art/imag_2.jpg", "title": "Orange cat", "subTitle": "1944"},
             {"imageSrc": "art/imag_3.jpg", "title": "Paper cat", "subTitle": "2002"}
           ]'
         ></music-section>
         <music-section
           title="New Relases"
-          tracks='[
+          albums='[
             {"imageSrc": "art/imag_3.jpg", "title": "Paper cat", "subTitle": "2002"},
             {"imageSrc": "art/imag_1.jpg", "title": "Two cats", "subTitle": "2023"},
             {"imageSrc": "art/imag_2.jpg", "title": "Orange cat", "subTitle": "1944"}
@@ -79,7 +79,7 @@
     </div>
 
     <script type="module">
-      import "./src/MusicTrack.ts";
+      import "./src/MusicAlbum.ts";
       import "./src/MusicSection.ts";
       import "./src/MusicSidebar.ts";
       import "./src/MusicTopbar.ts";

--- a/src/MusicAlbum.ts
+++ b/src/MusicAlbum.ts
@@ -1,8 +1,8 @@
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
-@customElement("music-track")
-export class MusicTrack extends LitElement {
+@customElement("music-album")
+export class MusicAlbum extends LitElement {
   static styles = css`
     :host {
       display: flex;
@@ -95,7 +95,7 @@ export class MusicTrack extends LitElement {
   subTitle = "";
 
   private handleTrackClick() {
-    const event = new CustomEvent("track-selected", {
+    const event = new CustomEvent("album-selected", {
       detail: {
         title: this.title,
         subTitle: this.subTitle,

--- a/src/MusicSection.ts
+++ b/src/MusicSection.ts
@@ -52,7 +52,7 @@ export class MusicSection extends LitElement {
       background-color: #ddd;
     }
 
-    .track-list{
+    .album-list{
       overflow-x: auto;
       max-width:100%;
       flex:1;
@@ -68,7 +68,7 @@ export class MusicSection extends LitElement {
         width:0px;
         border-radius: 100px;
     }
-    ::-webkit-scrollbar-track-piece {
+    ::-webkit-scrollbar-album-piece {
       background: #c2c2c2;
       border-radius: 100px;
       }
@@ -85,7 +85,7 @@ export class MusicSection extends LitElement {
   subTitle = "";
 
   @property({ type: Array })
-  tracks: { imageSrc: string; title: string; subTitle: string }[] = [];
+  albums: { imageSrc: string; title: string; subTitle: string }[] = [];
 
   private handleShowAll() {
     this.dispatchEvent(
@@ -106,15 +106,15 @@ export class MusicSection extends LitElement {
         </button>
       </div>
       ${this.subTitle ? html`<p>${this.subTitle}</p>` : ""}
-      <div class="tracks-container">
-        <div class="track-list">
-          ${this.tracks.map(
-      (track) => html`
-              <music-track
-                image-src=${track.imageSrc}
-                title=${track.title}
-                sub-title=${track.subTitle}
-              ></music-track>
+      <div class="albums-container">
+        <div class="album-list">
+          ${this.albums.map(
+      (album) => html`
+              <music-album
+                image-src=${album.imageSrc}
+                title=${album.title}
+                sub-title=${album.subTitle}
+              ></music-album>
             `
     )}
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { MusicTrack } from "./MusicTrack";
+export { MusicAlbum } from "./MusicAlbum";
 export { MusicSection } from "./MusicSection";
 export { MusicSidebar } from "./MusicSidebar";
 export { MusicTopbar } from "./MusicTopbar";


### PR DESCRIPTION
Ref: #1 

Issue:
Album component name is called "track" instead of "album"

Fix:
  - [x] object's name changed, 
  - [x] tag's name changed,
  - [x] related imports
  - [x] and music section.
  
 Screenshots:
![Muza-Lit-Library-Demo-02-27-2025_01_31_PM](https://github.com/user-attachments/assets/528f9479-d96d-4f60-bc9f-c3436e1a2b14)

 