### PR TITLE
fix/album-play-btn

### DIFF
--- a/app/components/albumDisplays/AlbumDetails.scss
+++ b/app/components/albumDisplays/AlbumDetails.scss
@@ -113,6 +113,8 @@
         height: 100%;
         svg {
           flex-shrink: 0;
+          width: 16px;
+          height: 16px;
           path {
             width: 16px;
             height: 16px;

--- a/app/components/albumDisplays/AlbumDetails.scss
+++ b/app/components/albumDisplays/AlbumDetails.scss
@@ -32,7 +32,7 @@
       left: 50%;
       top: 50%;
       transform: translate(-50%, -50%);
-      border-radius: var(--muza-border-radius-lg);
+      border-radius: 999px;
       background: var(--colors_primary_light, #1d4ed8);
       color: #fff;
       border: none;


### PR DESCRIPTION
Update border-radius in AlbumDetails.scss for a more circular overlay effect
<img width="204" height="258" alt="Screenshot 2025-08-17 at 14 47 07" src="https://github.com/user-
<img width="197" height="252" alt="Screenshot 2025-08-17 at 14 49 21" src="https://github.com/user-attachments/assets/8382c6bd-553b-4e54-9b3e-088f24d198c2" />
