### PR TITLE
Fix/home song line glitch

### DIFF
--- a/app/components/songLineDisplays/SongLineWithCover.scss
+++ b/app/components/songLineDisplays/SongLineWithCover.scss
@@ -242,6 +242,7 @@
     }
 
     .duration {
+      width: 36px;
       font-family:
         var(--typography_font_family_font_sans, "Founders Grotesk"), sans-serif;
       font-size: 14px;

--- a/app/routes/home.scss
+++ b/app/routes/home.scss
@@ -2,6 +2,7 @@
   background: var(--colors_background_light, #ffffff);
   padding: 0;
   margin: 0;
+  width: 100%;
   max-width: 1680px;
   align-self: center;
   .page-header {


### PR DESCRIPTION
On very wide screens when hovering on the songLine there was a glitch and the main homepage got suddenly a different width. solved.

<img width="2484" height="1140" alt="Screenshot 2025-09-01 at 12 49 00" src="https://github.com/user-attachments/assets/194e49f2-74ba-4608-8159-d6b2a31ac48d" />
