### PR TITLE
Fix/music player slider

### DIFF
--- a/app/controls/VolumeControl.scss
+++ b/app/controls/VolumeControl.scss
@@ -8,7 +8,7 @@
     cursor: pointer;
   }
 
-  .slider {
+  .volume-slider {
     width: 100px;
     height: 24px;
     cursor: pointer;

--- a/app/controls/VolumeControl.tsx
+++ b/app/controls/VolumeControl.tsx
@@ -108,7 +108,7 @@ const VolumeControl: React.FC<VolumeControlProps> = ({
           ></i>
         </>
       )}
-      <div className="slider" ref={sliderRef} onClick={handleSliderClick}>
+      <div className="volume-slider" ref={sliderRef} onClick={handleSliderClick}>
         <svg viewBox="0 0 100 24">
           <line className="track" x1="2" y1="12" x2="98" y2="12" />
           <line

--- a/app/controls/VolumeControl.tsx
+++ b/app/controls/VolumeControl.tsx
@@ -108,7 +108,11 @@ const VolumeControl: React.FC<VolumeControlProps> = ({
           ></i>
         </>
       )}
-      <div className="volume-slider" ref={sliderRef} onClick={handleSliderClick}>
+      <div
+        className="volume-slider"
+        ref={sliderRef}
+        onClick={handleSliderClick}
+      >
         <svg viewBox="0 0 100 24">
           <line className="track" x1="2" y1="12" x2="98" y2="12" />
           <line


### PR DESCRIPTION
The slider's class name was hoisted by another css property so I changed it's name to volume-slider